### PR TITLE
Improve the code style in the Scrape.Website module

### DIFF
--- a/lib/scrape/website.ex
+++ b/lib/scrape/website.ex
@@ -1,14 +1,15 @@
 defmodule Scrape.Website do
   @moduledoc """
-   very function in this module takes an HTML string, and returns some
-    data extracted from it, mostly strings. Floki is used for parsing
-    the raw HTML.
+  Every function in this module takes an HTML string, and returns some
+  data extracted from it, mostly strings. Floki is used for parsing
+  the raw HTML.
 
-    Usually, we want some general metadata from websites, not a deep text
-    analysis or the like. Since this is the foundation of a web crawler
-    in the future, the used algorithms should be as fast as possible, even
-    when the resulting quality suffers a little.
+  Usually, we want some general metadata from websites, not a deep text
+  analysis or the like. Since this is the foundation of a web crawler
+  in the future, the used algorithms should be as fast as possible, even
+  when the resulting quality suffers a little.
   """
+
   alias Scrape.Website
   alias Scrape.Exquery
   alias Scrape.Link
@@ -17,7 +18,6 @@ defmodule Scrape.Website do
     feeds: [], tags: []
 
   @spec parse(String.t, String.t) :: %Website{}
-
   def parse(html, url) do
     %Scrape.Website{
       url: url,
@@ -35,12 +35,11 @@ defmodule Scrape.Website do
   @doc """
     Returns the title of a HTML site
   """
-
   @spec find_title(String.t) :: String.t
-
   def find_title(html) do
     title = Exquery.find html, "title", :longest
     rx = ~r/\s[|-].{1}.+$/
+
     if title && String.match?(title, rx) do
       title
       |> String.split(rx)
@@ -53,38 +52,34 @@ defmodule Scrape.Website do
   @doc """
     Returns the description of a HTML site
   """
-
   @spec find_description(String.t) :: String.t
-
   def find_description(html) do
     selector = """
       meta[property='og:description'],
       meta[name='twitter:description'],
       meta[name='description']
     """
+
     Exquery.attr html, selector, "content", :longest
   end
 
   @doc """
     Returns the main image url of a HTML site
   """
-
   @spec find_image(String.t) :: String.t
-
   def find_image(html) do
     selector = """
       meta[property='og:image'],
       meta[name='twitter:image']
     """
+
     Exquery.attr html, selector, "content", :first
   end
 
   @doc """
     Returns the favicon url of a HTML site
   """
-
   @spec find_favicon(String.t) :: String.t
-
   def find_favicon(html) do
     selector = """
       link[rel='apple-touch-icon'],
@@ -92,31 +87,38 @@ defmodule Scrape.Website do
       link[rel='shortcut icon'],
       link[rel='icon']
     """
+
     favicon = Exquery.attr html, selector, "href", :first
+
     if favicon do
       favicon
     else
-      Exquery.attr html, "meta[name='msapplication-TileImage']", "content", :first
+      Exquery.attr html,
+        "meta[name='msapplication-TileImage']",
+	"content",
+        :first
     end
   end
 
   @doc """
     Returns a list of feed urls for a HTML site
   """
-
   @spec find_feeds(String.t) :: [String.t]
-
   def find_feeds(html) do
     selector = """
       link[type='application/rss+xml'],
       link[type='application/atom+xml'],
       link[rel='alternate']
     """
+
     feeds = Exquery.attr(html, selector, "href", :all)
+
     if length(feeds) > 0 do
       feeds
     else
-      Regex.scan(~r{href=['"]([^'"]*(rss|atom|feed|xml)[^'"]*)['"]}, html, capture: :all_but_first)
+      Regex.scan(~r{href=['"]([^'"]*(rss|atom|feed|xml)[^'"]*)['"]},
+        html,
+        capture: :all_but_first)
       |> Enum.map(fn matches -> List.first(matches) end)
     end
   end
@@ -124,9 +126,7 @@ defmodule Scrape.Website do
   @doc """
     Fetch the meta-keywords if exists
   """
-
   @spec find_tags(String.t) :: [%{name: String.t, accuracy: float}]
-
   def find_tags(html) do
     html
     |> Exquery.attr("meta[name=keywords]", "content", :all)
@@ -149,11 +149,10 @@ defmodule Scrape.Website do
   @doc """
     Look for a canonical url and use it, choose the given URL otherwise
   """
-
   @spec find_canonical(%Website{}, String.t) :: %Website{}
-
   def find_canonical(website, html) do
     canonical = Exquery.attr html, "link[rel=canonical]", "href"
+
     if !canonical || String.length(canonical) < 3 do
       website
     else
@@ -162,11 +161,10 @@ defmodule Scrape.Website do
   end
 
   @doc """
-    Iterate over all URLs in the website object and expand them to absolute ones
+    Iterate over all URLs in the website object and expand them to absolute
+    ones
   """
-
   @spec normalize_urls(%Website{}) :: %Website{}
-
   def normalize_urls(website) do
     website
     |> put_lazy(:image, fn(w) -> Link.expand(w.image, w.url) end)
@@ -193,5 +191,4 @@ defmodule Scrape.Website do
       website
     end
   end
-
 end


### PR DESCRIPTION
I erased some empty lines between doc-strings, specs and functions.
Also divided lines longer than 80 characters into multiple lines.
