### PR TITLE
fixed undefined function Date.now/0

### DIFF
--- a/lib/scrape/feed.ex
+++ b/lib/scrape/feed.ex
@@ -79,8 +79,8 @@ defmodule Scrape.Feed do
   ]
 
   defp try_date(str, patterns \\ @datetime_patterns)
-  defp try_date(nil, _), do: Date.now
-  defp try_date(_, []), do: Date.now
+  defp try_date(nil, _), do: Timex.Date.now
+  defp try_date(_, []), do: Timex.Date.now
   defp try_date(str, [format | others]) do
     case Timex.parse(str, format) do
       {:ok, result} -> result


### PR DESCRIPTION
I received errors below, then fixed that.

```
14:29:50.889 [error] Task #PID<0.1399.0> started from #PID<0.1389.0> terminating
** (UndefinedFunctionError) undefined function Date.now/0 (module Date is not available)
    Date.now()
    (scrape) lib/scrape/feed.ex:24: Scrape.Feed.transform_item/1
    (elixir) lib/task/supervised.ex:89: Task.Supervised.do_apply/2
    (elixir) lib/task/supervised.ex:40: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: #Function<12.38872584/0 in Parallel.map/2>
    Args: []
** (EXIT from #PID<0.1389.0>) an exception was raised:
    ** (UndefinedFunctionError) undefined function Date.now/0 (module Date is not available)
        Date.now()
        (scrape) lib/scrape/feed.ex:24: Scrape.Feed.transform_item/1
        (elixir) lib/task/supervised.ex:89: Task.Supervised.do_apply/2
        (elixir) lib/task/supervised.ex:40: Task.Supervised.reply/5
        (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

Thanks.
