### PR TITLE
mix: append to applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `scrape` to your mixfile:
 {:scrape, "~> 1.2"}
 ````
 
-and add `:scrape, :floki, :parallel, :timex` to your applications list in your mixfile.
+and add `:scrape` to your applications list in your mixfile.
 
 ## Usage
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Scrape.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :httpoison, :tzdata]]
+    [applications: [:logger, :httpoison, :tzdata,
+                    :floki, :parallel, :timex]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
So that downstream library consumers do not need to add these extra applications to their `mix.exs`.