### PR TITLE
Fixed deprecation warning in Elixir 1.4

### DIFF
--- a/lib/scrape/article.ex
+++ b/lib/scrape/article.ex
@@ -35,7 +35,7 @@ defmodule Scrape.Article do
       String.duplicate((article.description || ""), 5)
     |> Tags.from_text
     |> Enum.concat(article.tags)
-    |> Enum.uniq(fn t -> t.name end)
+    |> Enum.uniq_by(fn t -> t.name end)
     |> Enum.sort_by(fn t -> t.accuracy end)
     |> Enum.reverse
     %{article | tags: tags}

--- a/mix.exs
+++ b/mix.exs
@@ -5,12 +5,12 @@ defmodule Scrape.Mixfile do
     [app: :scrape,
      version: "1.2.7",
      elixir: "~> 1.3",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      dialyzer: [plt_add_deps: true],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
The main purpose of this pull request is to replace the use of Enum.uniq/2 with Enum.uniq_by/2 which has been deprecated in Elixir 1.4. I'm finding that this warning is particularly chatty and annoying in my scraper. However, this change will presumably make this no longer work with earlier versions of elixir. I think with such a young language though, this is probably the acceptable approach.

While doing this I also added parentheses to three parameterless function calls in mix.exs which were giving me warning messages when running the tests, although I think that this change is less important.